### PR TITLE
fixed problem with temp-dir on different drive on windows

### DIFF
--- a/flask_tex/__init__.py
+++ b/flask_tex/__init__.py
@@ -60,9 +60,9 @@ def run_tex(source, command, directory):
     filename = "texput.tex"
     with open(os.path.join(directory, filename), "x", encoding="utf-8") as f:
         f.write(source)
-    args = f'cd "{directory}" && {command} -interaction=batchmode {filename}'
+    args = f'{command} -interaction=batchmode {filename}'
     try:
-        run(args, shell=True, stdout=PIPE, stderr=PIPE, check=True)
+        run(args, cwd=directory, shell=True, stdout=PIPE, stderr=PIPE, check=True)
     except CalledProcessError:
         try:
             with open(os.path.join(directory, "texput.log"), "r") as f:


### PR DESCRIPTION
Hello, nice Project you got here. Here is a small fix for an issue I encountered.

When using this on windows and having the `TMP` directory on a different drive than the project directory, the code will fail because windows doesn't change the drive unless explicitly told to do so.

Luckiely, the subprocess module has an argument `cwd` to change the working directory befor spawning the child process. I implemented that. See documentation [here](https://docs.python.org/3/library/subprocess.html#popen-constructor)